### PR TITLE
[Docs] Updated developer workflow to use GitHub CLI for PR creation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -121,6 +121,11 @@ Tests are important while development. Whenever you add/update a functionality, 
     - Each commit should be logically atomic
     - Format: `[Type] Short description` e.g., `[Feature] Add live data fetching for BSE` or `[Fix] Handle missing data edge case`
 
-12. **Create a Pull Request (if applicable)**
-    - Link to the original issue/requirement
-    - Include summary of changes in PR description
+12. **Create a Pull Request using GitHub CLI**
+    - Use: `gh pr create --title "..." --body "..."`
+    - Title format: `[Type] Short description` (same as commit message)
+    - Include in body:
+      - Summary of changes
+      - Link to original issue/requirement (if applicable)
+      - Any testing notes or breaking changes
+    - Example: `gh pr create --title "[Docs] Refined developer workflow" --body "Updates the developer workflow with explicit step sequence."`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.2] - 2026-03-14
+
+### Changed
+- Updated developer workflow to use GitHub CLI (gh) for PR creation
+- Added detailed examples for gh pr create command
+
 ## [0.30.1] - 2026-03-14
 
 ### Changed


### PR DESCRIPTION
Updated step 12 of developer workflow to use GitHub CLI instead of browser. Includes detailed example of gh pr create command with proper formatting.