### PR TITLE
[Feature] Add corporate_integrated_filing() to NSELive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.0] - 2026-07-31
+
+### Added
+- `NSELive.corporate_integrated_filing()` — fetch corporate integrated filing results from NSE
+  - Supports filtering by market segment (`index`), `symbol`, `issuer`, `period_ended`, and date range
+  - Supports pagination via `page` and `size` parameters
+  - `filing_type` parameter allows fetching different filing categories (default: `'Integrated Filing- Financials'`)
+
 ## [0.33.1] - 2026-03-16
 
 ### Fixed

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -264,6 +264,20 @@ Get corporate announcements/disclosures.
 }
 ```
 
+#### `corporate_integrated_filing(index=None, symbol=None, issuer=None, period_ended=None, from_date=None, to_date=None, filing_type="Integrated Filing- Financials", page=1, size=20)`
+Get corporate integrated filing results (financial results, annual reports, etc.).
+
+**Parameters:**
+- `index` (str, optional): Market segment - `'equities'`, `'sme'`, etc.
+- `symbol` (str, optional): Stock symbol e.g. `'DIXON'`
+- `issuer` (str, optional): Full company name e.g. `'Dixon Technologies (India) Limited'`
+- `period_ended` (str, optional): Period filter e.g. `'all'`
+- `from_date` (date, optional): Start date filter (requires `to_date`)
+- `to_date` (date, optional): End date filter (requires `from_date`)
+- `filing_type` (str): Type of filing (default: `'Integrated Filing- Financials'`)
+- `page` (int): Page number for pagination (default: 1)
+- `size` (int): Results per page (default: 20)
+
 ---
 
 ## NSE Historical Data Module

--- a/docs/LIVE_DATA_GUIDE.md
+++ b/docs/LIVE_DATA_GUIDE.md
@@ -11,7 +11,8 @@ A comprehensive guide to fetching real-time market data using `jugaad-data`.
 5. [Live Derivatives Data](#live-derivatives-data)
 6. [Live Option Chains](#live-option-chains)
 7. [Corporate Announcements](#corporate-announcements)
-8. [Best Practices](#best-practices)
+8. [Corporate Integrated Filing](#corporate-integrated-filing)
+9. [Best Practices](#best-practices)
 
 ---
 
@@ -613,6 +614,64 @@ announcement = announcements[0]
 - Rights issue
 - Merger & Acquisition
 - Financial results
+
+---
+
+## Corporate Integrated Filing
+
+Fetch corporate integrated filing results (financial results, annual reports, etc.) from NSE.
+
+### Basic Usage
+
+```python
+from jugaad_data.nse import NSELive
+n = NSELive()
+
+# All recent filings
+filings = n.corporate_integrated_filing()
+
+# Filter by market segment
+filings = n.corporate_integrated_filing(index="equities")
+filings = n.corporate_integrated_filing(index="sme")
+
+# Filter by symbol and issuer
+filings = n.corporate_integrated_filing(
+    index="equities",
+    symbol="DIXON",
+    issuer="Dixon Technologies (India) Limited",
+    period_ended="all"
+)
+
+# Filter by date range
+from datetime import date
+filings = n.corporate_integrated_filing(
+    index="equities",
+    symbol="DIXON",
+    issuer="Dixon Technologies (India) Limited",
+    period_ended="all",
+    from_date=date(2026, 1, 1),
+    to_date=date(2026, 6, 30)
+)
+
+# Pagination
+filings = n.corporate_integrated_filing(index="equities", page=2, size=50)
+```
+
+### Parameters
+
+| Parameter     | Type           | Default                            | Description                                   |
+|---------------|----------------|------------------------------------|-----------------------------------------------|
+| `index`       | str (optional) | None                               | Market segment: `'equities'`, `'sme'`, etc.   |
+| `symbol`      | str (optional) | None                               | Stock symbol e.g. `'DIXON'`                   |
+| `issuer`      | str (optional) | None                               | Full company name                             |
+| `period_ended`| str (optional) | None                               | Period filter e.g. `'all'`                    |
+| `from_date`   | date (optional)| None                               | Start date (requires `to_date`)               |
+| `to_date`     | date (optional)| None                               | End date (requires `from_date`)               |
+| `filing_type` | str            | `'Integrated Filing- Financials'`  | Type of filing                                |
+| `page`        | int            | 1                                  | Page number for pagination                    |
+| `size`        | int            | 20                                 | Results per page                              |
+
+> **Note:** `from_date` and `to_date` must be provided together. Providing only one raises an exception.
 
 ---
 

--- a/jugaad_data/nse/live.py
+++ b/jugaad_data/nse/live.py
@@ -25,7 +25,8 @@ class NSELive:
             "currency_option_chain": "/option-chain-currency",
             "pre_open_market": "/market-data-pre-open",
             "holiday_list": "/holiday-master?type=trading",
-            "corporate_announcements": "/corporate-announcements"
+            "corporate_announcements": "/corporate-announcements",
+            "integrated_filing": "/integrated-filing-results"
     }
     
     def __init__(self):
@@ -220,6 +221,43 @@ class NSELive:
     @live_cache
     def holiday_list(self):
         return self.get("holiday_list", {})
+
+    def corporate_integrated_filing(self, index=None, symbol=None, issuer=None,
+                                     period_ended=None, from_date=None, to_date=None,
+                                     filing_type="Integrated Filing- Financials",
+                                     page=1, size=20):
+        """
+        Returns corporate integrated filing results from NSE.
+        (https://www.nseindia.com/companies-listing/corporate-filings-integrated-filing)
+
+        Args:
+            index:       Market segment - 'equities', 'sme', etc. (optional)
+            symbol:      Stock symbol e.g. 'DIXON' (optional)
+            issuer:      Full company name e.g. 'Dixon Technologies (India) Limited' (optional)
+            period_ended: Period filter e.g. 'all' or a specific period string (optional)
+            from_date:   datetime.date - start date filter (optional, requires to_date)
+            to_date:     datetime.date - end date filter (optional, requires from_date)
+            filing_type: Type of filing (default: 'Integrated Filing- Financials')
+            page:        Page number for pagination (default: 1)
+            size:        Number of results per page (default: 20)
+        """
+        payload = {"type": filing_type, "page": page, "size": size}
+
+        if index:
+            payload["index"] = index
+        if symbol:
+            payload["symbol"] = symbol
+        if issuer:
+            payload["issuer"] = issuer
+        if period_ended:
+            payload["period_ended"] = period_ended
+        if from_date and to_date:
+            payload["from_date"] = from_date.strftime("%d-%m-%Y")
+            payload["to_date"] = to_date.strftime("%d-%m-%Y")
+        elif from_date or to_date:
+            raise Exception("Please provide both from_date and to_date")
+
+        return self.get("integrated_filing", payload)
 
     def corporate_announcements(self, segment='equities', from_date=None, to_date=None, symbol=None):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jugaad-data"
-version = "0.33.1"
+version = "0.34.0"
 requires-python = ">= 3.9"
 authors = [{name = "jugaad-coder", email = "abc@xyz.com"}]
 description = "Free Zerodha API python library"

--- a/tests/test_nse_live.py
+++ b/tests/test_nse_live.py
@@ -95,6 +95,45 @@ def test_pre_open_market():
     assert "unchanged" in d
     assert "advances" in d
 
+def test_corporate_integrated_filing():
+    # All filings (no filters)
+    d = n.corporate_integrated_filing()
+    assert isinstance(d, dict) or isinstance(d, list)
+
+    # Filter by index
+    d = n.corporate_integrated_filing(index="equities")
+    assert isinstance(d, dict) or isinstance(d, list)
+
+    # Filter by index=sme
+    d = n.corporate_integrated_filing(index="sme")
+    assert isinstance(d, dict) or isinstance(d, list)
+
+    # Filter by symbol and issuer
+    d = n.corporate_integrated_filing(
+        index="equities",
+        symbol="DIXON",
+        issuer="Dixon Technologies (India) Limited",
+        period_ended="all"
+    )
+    assert isinstance(d, dict) or isinstance(d, list)
+
+    # Filter with date range
+    from datetime import date
+    d = n.corporate_integrated_filing(
+        index="equities",
+        symbol="DIXON",
+        issuer="Dixon Technologies (India) Limited",
+        period_ended="all",
+        from_date=date(2026, 1, 1),
+        to_date=date(2026, 6, 30)
+    )
+    assert isinstance(d, dict) or isinstance(d, list)
+
+    # Ensure partial date raises exception
+    import pytest
+    with pytest.raises(Exception):
+        n.corporate_integrated_filing(from_date=date(2026, 1, 1))
+
 def test_corporate_announcements():
     d = n.corporate_announcements()
     assert type(d) == list


### PR DESCRIPTION
- Add new method to fetch corporate integrated filing results from NSE
- Supports filtering by index, symbol, issuer, period_ended, date range
- Supports pagination via page and size parameters
- Add tests, update API_REFERENCE, LIVE_DATA_GUIDE, CHANGELOG
- Bump version to 0.34.0