### PR TITLE
fix: race condition when creating cache directory

### DIFF
--- a/jugaad_data/util.py
+++ b/jugaad_data/util.py
@@ -104,8 +104,7 @@ def cached(app_name):
             file_name = kw_to_fname(**kw)
             path = os.path.join(cache_dir, file_name)
             if not os.path.isfile(path):    
-                if not os.path.exists(cache_dir):
-                    os.makedirs(cache_dir)
+                os.makedirs(cache_dir, exist_ok=True)
                 j = function(**kw)
                 with open(path, 'wb') as fp:
                     pickle.dump(j, fp)        


### PR DESCRIPTION
## Summary

This PR replaces:

```python
if not os.path.exists(cache_dir):
    os.makedirs(cache_dir)
```

with:

```python
os.makedirs(cache_dir, exist_ok=True)
```

## Motivation

The current implementation performs a non-atomic check-then-create sequence.

If multiple callers attempt to initialize the cache directory concurrently, they
can both observe that the directory does not exist. One caller creates the
directory successfully while the other raises:

```
FileExistsError: [Errno 17] File exists: '<cache_dir>'
```

Using `os.makedirs(..., exist_ok=True)` makes directory creation idempotent,
eliminates this race condition, and preserves the existing behavior.

## Reproduction

The issue can be reproduced with concurrent calls to the existing pattern:

```python
from concurrent.futures import ThreadPoolExecutor
import os
import shutil

CACHE_DIR = "/tmp/jugaad-cache-test"

def create_cache():
    if not os.path.exists(CACHE_DIR):
        os.makedirs(CACHE_DIR)

shutil.rmtree(CACHE_DIR, ignore_errors=True)

with ThreadPoolExecutor(max_workers=20) as executor:
    futures = [executor.submit(create_cache) for _ in range(100)]
    for future in futures:
        future.result()
```

This intermittently raises:

```
FileExistsError: [Errno 17] File exists: '/tmp/jugaad-cache-test'
```

Replacing the directory creation with:

```python
os.makedirs(CACHE_DIR, exist_ok=True)
```

removes the race while preserving the original functionality.