### PR TITLE
Move live/network tests out of CI into pre-push git hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# pre-push hook
+# -------------
+# Runs the "live" network tests (real API calls to BSE/NSE) before pushing.
+# These tests are intentionally NOT mocked so that any change to the external
+# APIs surfaces as a test failure before the code reaches the remote.
+#
+# These tests are slow and depend on the network, so they are excluded from the
+# CI pipeline (which runs `pytest` with the default `-m "not live"` filter) and
+# instead run here on every push.
+#
+# To enable this hook for your checkout, run:
+#     git config core.hooksPath .githooks
+#
+# Skip with:  git push --no-verify
+#
+set -euo pipefail
+
+# Use the project virtualenv python if present, else fall back to python3.
+if [[ -x "env/bin/python" ]]; then
+    PY="env/bin/python"
+else
+    PY="python3"
+fi
+
+echo "==> Running live (network) tests before push..."
+if ! "$PY" -m pytest -m live -p no:cacheprovider -q; then
+    echo
+    echo "!! Live tests failed. This usually means the BSE/NSE API has changed."
+    echo "   Update the code and tests to match the new API before pushing."
+    echo "   To skip these checks:  git push --no-verify"
+    exit 1
+fi
+echo "==> Live tests passed."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,13 +2,12 @@
 #
 # pre-push hook
 # -------------
-# Runs the "live" network tests (real API calls to BSE/NSE) before pushing.
-# These tests are intentionally NOT mocked so that any change to the external
-# APIs surfaces as a test failure before the code reaches the remote.
+# Runs ALL tests (including live network calls to BSE/NSE) before pushing.
+# Live tests are intentionally NOT mocked so that any change to the external
+# APIs surfaces as a failure before the code reaches the remote.
 #
-# These tests are slow and depend on the network, so they are excluded from the
-# CI pipeline (which runs `pytest` with the default `-m "not live"` filter) and
-# instead run here on every push.
+# CI only runs non-live tests (pytest -m "not live") because network tests are
+# slow and unreliable in CI. The pre-push hook is the gating check for those.
 #
 # To enable this hook for your checkout, run:
 #     git config core.hooksPath .githooks
@@ -24,12 +23,11 @@ else
     PY="python3"
 fi
 
-echo "==> Running live (network) tests before push..."
-if ! "$PY" -m pytest -m live -p no:cacheprovider -q; then
+echo "==> Running all tests before push..."
+if ! "$PY" -m pytest -p no:cacheprovider -q; then
     echo
-    echo "!! Live tests failed. This usually means the BSE/NSE API has changed."
-    echo "   Update the code and tests to match the new API before pushing."
+    echo "!! Tests failed. Review failures above before pushing."
     echo "   To skip these checks:  git push --no-verify"
     exit 1
 fi
-echo "==> Live tests passed."
+echo "==> All tests passed."

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,8 +8,6 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
 
 permissions:
   contents: read

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,8 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 
 permissions:
   contents: read

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,4 +38,5 @@ jobs:
         echo "Disabled linting"
     - name: Test with pytest
       run: |
-        pytest
+        # Skip live (network) tests - they run via the pre-push git hook
+        pytest -m "not live"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,12 @@ Never `pip install <pkg>` directly. Add new dependencies to `requirements.txt` (
 
 ### Run tests
 ```bash
-env/bin/python -m pytest                              # non-live tests (default)
-env/bin/python -m pytest -m live                      # live/network tests
+env/bin/python -m pytest                              # all tests
+env/bin/python -m pytest -m live                      # live/network tests only
 env/bin/python -m pytest tests/test_nse.py            # single file
 env/bin/python -m pytest tests/test_nse.py::test_cookie  # single test
 ```
-Always use `env/bin/python -m pytest`. Bare `pytest` may pick up system Python. `pytest.ini` sets `testpaths = tests` to prevent crawling into `env/`, and adds `-m "not live"` so the default invocation skips network tests.
+Always use `env/bin/python -m pytest`. Bare `pytest` may pick up system Python. `pytest.ini` sets `testpaths = tests` to prevent crawling into `env/`.
 
 ### Live vs offline tests
 Tests that make real network calls against external APIs (BSE/NSE) are marked `@pytest.mark.live`. They are **intentionally not mocked** so that any change to the upstream API surfaces as a failure. Because they are slow and depend on the network, they are excluded from CI and instead run on every `git push` via the `pre-push` hook.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Always use `env/bin/python -m pytest`. Bare `pytest` may pick up system Python. 
 Tests that make real network calls against external APIs (BSE/NSE) are marked `@pytest.mark.live`. They are **intentionally not mocked** so that any change to the upstream API surfaces as a failure. Because they are slow and depend on the network, they are excluded from CI and instead run on every `git push` via the `pre-push` hook.
 
 - CI runs `pytest -m "not live"`.
-- `pre-push` hook runs `pytest -m live`.
+- `pre-push` hook runs all tests (including live).
 
 To enable the hook for your checkout:
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,24 @@ Never `pip install <pkg>` directly. Add new dependencies to `requirements.txt` (
 
 ### Run tests
 ```bash
-env/bin/python -m pytest                              # all tests
+env/bin/python -m pytest                              # non-live tests (default)
+env/bin/python -m pytest -m live                      # live/network tests
 env/bin/python -m pytest tests/test_nse.py            # single file
 env/bin/python -m pytest tests/test_nse.py::test_cookie  # single test
 ```
-Always use `env/bin/python -m pytest`. Bare `pytest` may pick up system Python. `pytest.ini` sets `testpaths = tests` to prevent crawling into `env/`.
+Always use `env/bin/python -m pytest`. Bare `pytest` may pick up system Python. `pytest.ini` sets `testpaths = tests` to prevent crawling into `env/`, and adds `-m "not live"` so the default invocation skips network tests.
+
+### Live vs offline tests
+Tests that make real network calls against external APIs (BSE/NSE) are marked `@pytest.mark.live`. They are **intentionally not mocked** so that any change to the upstream API surfaces as a failure. Because they are slow and depend on the network, they are excluded from CI and instead run on every `git push` via the `pre-push` hook.
+
+- CI runs `pytest -m "not live"`.
+- `pre-push` hook runs `pytest -m live`.
+
+To enable the hook for your checkout:
+```bash
+git config core.hooksPath .githooks
+```
+To skip live checks on a push: `git push --no-verify`.
 
 ### Watch tests (auto-rerun on change)
 ```bash

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,8 @@
 [pytest]
 testpaths = tests
+# Add -m "not live" so the default pytest invocation skips network tests.
+# Live (network) tests are run via the pre-push git hook instead.
+addopts = -m "not live"
+markers =
+    live: tests that make real network calls against external APIs (BSE/NSE).
+        These are slow and change over time; they run via the pre-push hook.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,5 @@
 [pytest]
 testpaths = tests
-# Add -m "not live" so the default pytest invocation skips network tests.
-# Live (network) tests are run via the pre-push git hook instead.
-addopts = -m "not live"
 markers =
     live: tests that make real network calls against external APIs (BSE/NSE).
         These are slow and change over time; they run via the pre-push hook.

--- a/tests/test_bhav.py
+++ b/tests/test_bhav.py
@@ -15,6 +15,7 @@ def test_bhavcopy():
     assert "RELIANCE" in r or "SBIN" in r  # At least some stock data present
     assert header in r
 
+@pytest.mark.live
 def test_bhavcopy_recent():
     """Test bhavcopy for recent date using UDiff format
     

--- a/tests/test_bhav.py
+++ b/tests/test_bhav.py
@@ -15,26 +15,16 @@ def test_bhavcopy():
     assert "RELIANCE" in r or "SBIN" in r  # At least some stock data present
     assert header in r
 
-@pytest.mark.live
 def test_bhavcopy_recent():
     """Test bhavcopy for recent date using UDiff format
     
     For dates >= Jul 8, 2024, should use UDiff format from daily-reports API.
     UDiff format has different columns: TradDt,BizDt,Sgmt,Src,FinInstrmTp,...
+    Uses a fixed past trading date so the response is cached and reliable.
     """
-    from datetime import datetime, timedelta
-    # Get a recent trading date
-    today = date.today()
-    # Skip if today is not a trading day (simplified check)
-    try:
-        r = bhavcopy_raw(today)
-        # Check that we got data (either format)
-        assert len(r) > 0
-        # Should have ISIN field in both formats
-        assert "ISIN" in r
-    except requests.RequestException:
-        # API may not have data for weekend/holiday
-        pytest.skip("No data available for today")
+    r = bhavcopy_raw(date(2024, 7, 10))
+    assert len(r) > 0
+    assert "ISIN" in r
 
 # def test_full_bhavcopy():
 #     r = full_bhavcopy_raw(date(2020,1,1))

--- a/tests/test_bse_live.py
+++ b/tests/test_bse_live.py
@@ -37,6 +37,7 @@ def test_get_attachment_url():
     url_empty = bse.get_attachment_url("")
     assert url_empty is None
 
+@pytest.mark.live
 def test_corporate_announcements_basic():
     """Test basic corporate announcements functionality - single quick API call"""
     bse = BSELive()
@@ -55,6 +56,7 @@ def test_corporate_announcements_basic():
     assert isinstance(result["Table"], list)
     assert isinstance(result["Table1"], list)
 
+@pytest.mark.live
 def test_get_announcement_with_urls():
     """Test convenience method that includes attachment URLs"""
     bse = BSELive()
@@ -76,6 +78,7 @@ def test_get_announcement_with_urls():
         assert "attachment_url" in announcement
         assert "file_size_formatted" in announcement
 
+@pytest.mark.live
 def test_get_scrip_list():
     """Test scrip list functionality"""
     bse = BSELive()
@@ -92,6 +95,7 @@ def test_get_scrip_list():
         assert "scrip_id" in scrip
         assert "Scrip_Name" in scrip
 
+@pytest.mark.live
 def test_symbol_conversions():
     """Test symbol to scrip code conversion and vice versa"""
     bse = BSELive()
@@ -118,6 +122,7 @@ def test_symbol_conversions():
     invalid_code = bse.symbol_to_scrip_code("NONEXISTENT")
     assert invalid_code is None
 
+@pytest.mark.live
 def test_get_scrip_info():
     """Test getting detailed scrip information"""
     bse = BSELive()
@@ -138,6 +143,7 @@ def test_get_scrip_info():
     invalid_info = bse.get_scrip_info("NONEXISTENT")
     assert invalid_info is None
 
+@pytest.mark.live
 def test_corporate_announcements_by_symbol():
     """Test corporate announcements using symbol instead of scrip code"""
     bse = BSELive()

--- a/tests/test_nse_live.py
+++ b/tests/test_nse_live.py
@@ -3,10 +3,12 @@ from jugaad_data.nse.live import NSELive
 from datetime import date, datetime
 n = NSELive()
 
+@pytest.mark.live
 def test_stock_quote():
     r = n.stock_quote("HDFCBANK")
     assert r['metaData']['symbol'] == 'HDFCBANK'
 
+@pytest.mark.live
 def test_stock_quote_fno():
     # Use a symbol with active derivatives (NIFTY or RELIANCE)
     r = n.stock_quote_fno("RELIANCE")
@@ -25,27 +27,32 @@ def test_stock_quote_fno():
     assert 'expiryDate' in contract
     assert 'lastPrice' in contract or contract.get('lastPrice') is not None
 
+@pytest.mark.live
 def test_trade_info():
     r = n.trade_info("HDFCBANK")
     assert "orderBook" in r
     assert "tradeInfo" in r
 
+@pytest.mark.live
 def test_market_status():
     r = n.market_status()
     assert "marketState" in r
 
+@pytest.mark.live
 def test_tick_data():
     d = n.tick_data("HDFC")
     assert "grapthData" in d
     d = n.tick_data("NIFTY 50", True)
     assert "grapthData" in d
 """
+@pytest.mark.live
 def test_market_turnover():
     d = n.market_turnover()
     assert "data" in d
     assert len(d['data']) > 1
     assert 'name' in d['data'][0]
 """
+@pytest.mark.live
 def test_eq_derivative_turnover():
     d = n.eq_derivative_turnover()
     assert "value" in d
@@ -59,47 +66,55 @@ def test_eq_derivative_turnover():
     assert len(d['value']) > 1
     assert len(d['volume']) > 1
 
+@pytest.mark.live
 def test_all_indices():
     d = n.all_indices()
     assert "advances" in d
     assert "declines" in d
     assert len(d['data']) > 1
 
+@pytest.mark.live
 def test_live_index():
     fresh = NSELive()
     d = fresh.live_index("NIFTY 50")
     assert "data" in d
     assert len(d['data']) >= 1
 
+@pytest.mark.live
 def test_index_option_chain():
     d = n.index_option_chain("NIFTY")
     assert "filtered" in d
     assert "records" in d
 
+@pytest.mark.live
 def test_equities_option_chain():
     d = n.equities_option_chain("RELIANCE")
     assert "filtered" in d
     assert "records" in d
     assert "data" in d["records"]
 
+@pytest.mark.live
 def test_currency_option_chain():
     d = n.currency_option_chain("USDINR")
     assert "filtered" in d
     assert "records" in d
     assert "data" in d["records"]
 
+@pytest.mark.live
 def test_live_fno():
     fresh = NSELive()
     d = fresh.live_fno()
     assert "data" in d
     assert "marketStatus" in d
 
+@pytest.mark.live
 def test_pre_open_market():
     d = n.pre_open_market("NIFTY")
     assert "declines" in d
     assert "unchanged" in d
     assert "advances" in d
 
+@pytest.mark.live
 def test_corporate_integrated_filing():
     # All filings (no filters)
     d = n.corporate_integrated_filing()
@@ -139,6 +154,7 @@ def test_corporate_integrated_filing():
     with pytest.raises(Exception):
         n.corporate_integrated_filing(from_date=date(2026, 1, 1))
 
+@pytest.mark.live
 def test_corporate_announcements():
     d = n.corporate_announcements()
     assert type(d) == list


### PR DESCRIPTION
## Problem

`test_bse_live.py` and other tests making real network API calls (BSE/NSE) are slow and fail in CI (blocked/rate-limited API responses).

## Solution

- Tagged network-dependent tests with `@pytest.mark.live`
- CI runs `pytest -m "not live"` to skip live tests
- New `.githooks/pre-push` hook runs all tests (including live) on every push — this is the gating check that catches upstream API changes
- Fixed `test_bhavcopy_recent` to use a fixed past date (was using `date.today()` which fails when market hasn't started)
- Default `pytest` still runs everything; CI and hook explicitly opt in/out of live tests

## Usage

To enable the hook for your checkout:
```bash
git config core.hooksPath .githooks
```

Skip checks on push: `git push --no-verify`